### PR TITLE
Updating for Gnome-Shell 3.20

### DIFF
--- a/bumblebee-indicator@gnome-shell-extensions.majcn.github.com/metadata.json
+++ b/bumblebee-indicator@gnome-shell-extensions.majcn.github.com/metadata.json
@@ -1,6 +1,6 @@
 
 {
-    "shell-version": ["3.6.2", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18"],
+    "shell-version": ["3.6.2", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"],
     "uuid": "bumblebee-indicator@gnome-shell-extensions.meden.github.com",
     "name": "Bumblebee Indicator",
     "description": "A Gnome Shell extension that indicates your Nvidia card status while using Bumblebee",


### PR DESCRIPTION
Added 3.20 to the list of gnome-shell supported versions.
